### PR TITLE
feat: update error handling

### DIFF
--- a/src/login/refreshToken.ts
+++ b/src/login/refreshToken.ts
@@ -19,7 +19,8 @@ type JsonRpcErrorType =
   | 'FunctionCallError'
   | 'CallError'
   | 'MissmatchedRequestIdError'
-  | 'InvalidRequestError';
+  | 'InvalidRequestError'
+  | 'ParseError';
 
 const errorTypes: JsonRpcErrorType[] = [
   'UnknownServerError',
@@ -28,6 +29,7 @@ const errorTypes: JsonRpcErrorType[] = [
   'CallError',
   'MissmatchedRequestIdError',
   'InvalidRequestError',
+  'ParseError',
 ];
 
 export const getNewJwtToken = async ({

--- a/src/rpc/jsonrpc.ts
+++ b/src/rpc/jsonrpc.ts
@@ -19,12 +19,14 @@ interface JsonRpcRequest<Params> {
   params: Params;
 }
 
+type DataType = {
+  type: string;
+  [key: string]: any;
+};
+
 interface ErrorData {
   data: {
-    data: {
-      type: string;
-      [key: string]: any;
-    };
+    data: string | DataType;
     type: string;
   };
   type: string;
@@ -132,6 +134,13 @@ export class JsonRpcClient implements RpcClient {
         }
 
         if (response?.data?.error) {
+          let messageData = response?.data?.error?.data;
+          let errorMessage = "";
+          if (typeof messageData === 'string') {
+            errorMessage = messageData;
+          } else {
+            errorMessage = messageData.type;
+          }
           return {
             error: {
               code: 400,
@@ -144,7 +153,7 @@ export class JsonRpcClient implements RpcClient {
                     response?.data?.error?.data?.type ??
                     response?.data?.error?.type,
                   info: {
-                    message: response?.data?.error?.data?.data?.type,
+                    message: errorMessage,
                   },
                 },
               },
@@ -155,6 +164,13 @@ export class JsonRpcClient implements RpcClient {
           result: response?.data?.result,
         };
       } else {
+        let messageData = response?.data?.error?.data?.data;
+          let errorMessage = "";
+          if (typeof messageData === 'string') {
+            errorMessage = messageData;
+          } else {
+            errorMessage = messageData.type;
+          }
         return {
           error: {
             id: response?.data?.id,
@@ -165,7 +181,7 @@ export class JsonRpcClient implements RpcClient {
               cause: {
                 name: 'InvalidRequestError',
                 info: {
-                  message: response?.data?.error?.data?.data?.type,
+                  message: errorMessage,
                 },
               },
             },
@@ -177,13 +193,13 @@ export class JsonRpcClient implements RpcClient {
         error: {
           id: requestId,
           jsonrpc: '2.0',
-          code: error.response.code,
+          code: 500,
           error: {
             name: 'UnknownServerError',
             cause: {
               name: 'UnknownServerError',
               info: {
-                message: error?.response?.data,
+                message: `${error.message ?? error?.response?.data}.\n Verify that the node server is running.` ,
               },
             },
           },

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -49,7 +49,7 @@ export interface RpcErrorInfo {
 export interface RpcError {
   id: RpcRequestId;
   jsonrpc: string;
-  code: number;
+  code?: number;
   error: RpcErrorInfo;
 }
 

--- a/watch-script.sh
+++ b/watch-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf node_modules dist lib && pnpm install
+
+if [ $? -ne 0 ]; then
+  echo "pnpm install failed. Exiting."
+  exit 1
+fi
+
+pnpm run watch


### PR DESCRIPTION
## Description

First implementation of error handling was with older version of node. Meanwhile some of the outputs changed and needed to be covered.
This included:
- invalid application method
- invalid contextID
- invalid executor public key
- error when node server is not running
- error when there is application logic error
- serialization error
- unauthorized error
- state
-  not initilized error

## Test plan

![Screenshot 2025-04-02 at 13 03 35](https://github.com/user-attachments/assets/7a9ff2e8-17e8-4ed4-9704-e48059a91b3a)
![Screenshot 2025-04-02 at 13 03 24](https://github.com/user-attachments/assets/93cb52e8-7481-4609-bd2c-a035dea69ce0)
![Screenshot 2025-04-02 at 13 09 08](https://github.com/user-attachments/assets/a58eeefa-74f7-40d1-87fa-5fb46398a29d)
![Screenshot 2025-04-02 at 13 02 45](https://github.com/user-attachments/assets/1441791d-3316-469b-b259-9b168fd84afc)
![Screenshot 2025-04-02 at 12 57 25](https://github.com/user-attachments/assets/3440f0d8-8bbc-44b0-95a9-3841efa043ba)
![Screenshot 2025-04-02 at 13 03 08](https://github.com/user-attachments/assets/f42d346d-c1b3-4080-9d7b-200b850b1e8b)
![Screenshot 2025-04-02 at 12 57 17](https://github.com/user-attachments/assets/a60df89d-a024-4982-afe0-9fd4b61975fc)
![Screenshot 2025-04-02 at 13 02 57](https://github.com/user-attachments/assets/d3a210a1-5d03-4f0a-93ca-54cda5ab86ae)


## Documentation plan 
N/A