### PR TITLE
fix: cleanup deprecated methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-network/calimero-client",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/src/rpc/jsonrpc.ts
+++ b/src/rpc/jsonrpc.ts
@@ -5,8 +5,6 @@ import {
   RpcQueryParams,
   RequestConfig,
   RpcResult,
-  RpcMutateParams,
-  RpcMutateResponse,
 } from '../types/rpc';
 import axios, { AxiosInstance } from 'axios';
 
@@ -57,34 +55,6 @@ export class JsonRpcClient implements RpcClient {
       baseURL: baseUrl,
       timeout: defaultTimeout,
     });
-  }
-
-  /**
-   * @deprecated The method should not be used, use execute instead.
-   */
-  public async query<Args, Output>(
-    params: RpcQueryParams<Args>,
-    config?: RequestConfig,
-  ): Promise<RpcResult<RpcQueryResponse<Output>>> {
-    return await this.request<RpcQueryParams<Args>, RpcQueryResponse<Output>>(
-      'execute',
-      params,
-      config,
-    );
-  }
-
-  /**
-   * @deprecated The method should not be used, use execute instead.
-   */
-  public async mutate<Args, Output>(
-    params: RpcMutateParams<Args>,
-    config?: RequestConfig,
-  ): Promise<RpcResult<RpcMutateResponse<Output>>> {
-    return await this.request<RpcMutateParams<Args>, RpcMutateResponse<Output>>(
-      'execute',
-      params,
-      config,
-    );
   }
 
   /**

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -3,14 +3,6 @@ import { ContextId } from './context';
 export type RpcRequestId = string | number;
 
 export interface RpcClient {
-  query<Args, Out>(
-    params: RpcQueryParams<Args>,
-    config?: RequestConfig,
-  ): Promise<RpcResult<RpcQueryResponse<Out>>>;
-  mutate<Args, Out>(
-    params: RpcMutateParams<Args>,
-    config?: RequestConfig,
-  ): Promise<RpcResult<RpcMutateResponse<Out>>>;
   execute<Args, Out>(
     params: RpcQueryParams<Args>,
     config?: RequestConfig,
@@ -61,16 +53,5 @@ export interface RpcQueryParams<Args> {
 }
 
 export interface RpcQueryResponse<Output> {
-  output?: Output;
-}
-
-export interface RpcMutateParams<Args> {
-  contextId: ContextId;
-  method: string;
-  argsJson: Args;
-  executorPublicKey: string;
-}
-
-export interface RpcMutateResponse<Output> {
   output?: Output;
 }


### PR DESCRIPTION
## Description

Remove json rpc methods that are deprecated ( query / mutate )

## Test plan
 
N/A

## Documentation update

N/A