### PR TITLE
fix(Blob): blob handlers

### DIFF
--- a/src/api/dataSource/BlobApiDataSource.ts
+++ b/src/api/dataSource/BlobApiDataSource.ts
@@ -24,7 +24,7 @@ export class BlobApiDataSource implements BlobApi {
   ): ApiResponse<BlobUploadResponse> {
     try {
       const fileArrayBuffer = await file.arrayBuffer();
-      
+
       let url = `${this.baseUrl}/admin-api/blobs`;
       const params = new URLSearchParams();
       if (expectedHash) {
@@ -70,9 +70,7 @@ export class BlobApiDataSource implements BlobApi {
         error: {
           code: 500,
           message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to upload blob',
+            error instanceof Error ? error.message : 'Failed to upload blob',
         },
       };
     }
@@ -114,9 +112,7 @@ export class BlobApiDataSource implements BlobApi {
       const contentLength = headers['content-length'];
       const size = contentLength ? parseInt(contentLength, 10) : 0;
       const fileType =
-        headers['x-blob-mime-type'] ||
-        headers['content-type'] ||
-        'unknown';
+        headers['x-blob-mime-type'] || headers['content-type'] || 'unknown';
       const responseBlobId = headers['x-blob-id'];
 
       return {

--- a/src/api/dataSource/BlobApiDataSource.ts
+++ b/src/api/dataSource/BlobApiDataSource.ts
@@ -50,15 +50,11 @@ export class BlobApiDataSource implements BlobApi {
         };
       }
 
-      console.log('response', response);
-
       // Transform snake_case to camelCase
       const transformedResponse: BlobUploadResponse = {
         blobId: response.data!.blob_id,
         size: response.data!.size,
       };
-
-      console.log('transformedResponse', transformedResponse);
 
       return {
         data: transformedResponse,

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -16,6 +16,15 @@ export interface Header {
   [key: string]: string;
 }
 
+export interface ProgressCallback {
+  (progress: number): void;
+}
+
+export interface HeadResponse {
+  headers: Record<string, string>;
+  status: number;
+}
+
 export interface HttpClient {
   get<T>(
     url: string,
@@ -33,6 +42,7 @@ export interface HttpClient {
     body?: unknown,
     headers?: Header[],
     isJsonRpc?: boolean,
+    onUploadProgress?: ProgressCallback,
   ): Promise<ResponseData<T>>;
   delete<T>(
     url: string,
@@ -45,7 +55,7 @@ export interface HttpClient {
     headers?: Header[],
     isJsonRpc?: boolean,
   ): Promise<ResponseData<T>>;
-  head(url: string, headers?: Header[]): Promise<ResponseData<void>>;
+  head(url: string, headers?: Header[]): Promise<ResponseData<HeadResponse>>;
 }
 
 export class AxiosHttpClient implements HttpClient {
@@ -153,8 +163,23 @@ export class AxiosHttpClient implements HttpClient {
       const response = await promise;
 
       if (response?.config?.method?.toUpperCase() === 'HEAD') {
+        // For HEAD requests, return headers and status
+        // Convert axios headers to string record
+        const headers: Record<string, string> = {};
+        if (response.headers) {
+          Object.entries(response.headers).forEach(([key, value]) => {
+            if (value !== undefined) {
+              headers[key] = Array.isArray(value) ? value.join(', ') : String(value);
+            }
+          });
+        }
+        
+        const headResponse: HeadResponse = {
+          headers,
+          status: response.status,
+        };
         return {
-          data: null as T,
+          data: headResponse as T,
           error: null,
         };
       }
@@ -324,16 +349,30 @@ export class AxiosHttpClient implements HttpClient {
     body?: unknown,
     headers?: Header[],
     isJsonRpc = false,
+    onUploadProgress?: ProgressCallback,
   ): Promise<ResponseData<T>> {
     const authHeaders = this.getAuthHeaders();
     const mergedHeaders = headers?.reduce(
       (acc, curr) => ({ ...acc, ...curr }),
       {},
     );
+    
+    const config: any = {
+      headers: { ...authHeaders, ...mergedHeaders },
+    };
+    
+    // Add upload progress callback if provided
+    if (onUploadProgress) {
+      config.onUploadProgress = (progressEvent: any) => {
+        if (progressEvent.lengthComputable) {
+          const progress = (progressEvent.loaded / progressEvent.total) * 100;
+          onUploadProgress(progress);
+        }
+      };
+    }
+    
     return this.request(
-      this.axios.put<T>(url, body, {
-        headers: { ...authHeaders, ...mergedHeaders },
-      }),
+      this.axios.put<T>(url, body, config),
       isJsonRpc,
     );
   }
@@ -375,7 +414,7 @@ export class AxiosHttpClient implements HttpClient {
     );
   }
 
-  async head(url: string, headers?: Header[]): Promise<ResponseData<void>> {
+  async head(url: string, headers?: Header[]): Promise<ResponseData<HeadResponse>> {
     const authHeaders = this.getAuthHeaders();
     const mergedHeaders = headers?.reduce(
       (acc, curr) => ({ ...acc, ...curr }),

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -169,11 +169,13 @@ export class AxiosHttpClient implements HttpClient {
         if (response.headers) {
           Object.entries(response.headers).forEach(([key, value]) => {
             if (value !== undefined) {
-              headers[key] = Array.isArray(value) ? value.join(', ') : String(value);
+              headers[key] = Array.isArray(value)
+                ? value.join(', ')
+                : String(value);
             }
           });
         }
-        
+
         const headResponse: HeadResponse = {
           headers,
           status: response.status,
@@ -356,11 +358,11 @@ export class AxiosHttpClient implements HttpClient {
       (acc, curr) => ({ ...acc, ...curr }),
       {},
     );
-    
+
     const config: any = {
       headers: { ...authHeaders, ...mergedHeaders },
     };
-    
+
     // Add upload progress callback if provided
     if (onUploadProgress) {
       config.onUploadProgress = (progressEvent: any) => {
@@ -370,11 +372,8 @@ export class AxiosHttpClient implements HttpClient {
         }
       };
     }
-    
-    return this.request(
-      this.axios.put<T>(url, body, config),
-      isJsonRpc,
-    );
+
+    return this.request(this.axios.put<T>(url, body, config), isJsonRpc);
   }
 
   async delete<T>(
@@ -414,7 +413,10 @@ export class AxiosHttpClient implements HttpClient {
     );
   }
 
-  async head(url: string, headers?: Header[]): Promise<ResponseData<HeadResponse>> {
+  async head(
+    url: string,
+    headers?: Header[],
+  ): Promise<ResponseData<HeadResponse>> {
     const authHeaders = this.getAuthHeaders();
     const mergedHeaders = headers?.reduce(
       (acc, curr) => ({ ...acc, ...curr }),

--- a/src/experimental/CalimeroProvider.tsx
+++ b/src/experimental/CalimeroProvider.tsx
@@ -94,9 +94,10 @@ export const CalimeroProvider: React.FC<CalimeroProviderProps> = ({
   }, []);
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const encodedAccessToken = urlParams.get('access_token');
-    const encodedRefreshToken = urlParams.get('refresh_token');
+    const fragment = window.location.hash.substring(1); // Remove the leading #
+    const fragmentParams = new URLSearchParams(fragment);
+    const encodedAccessToken = fragmentParams.get('access_token');
+    const encodedRefreshToken = fragmentParams.get('refresh_token');
 
     if (encodedAccessToken && encodedRefreshToken) {
       window.history.replaceState({}, document.title, window.location.pathname);

--- a/src/login/ClientLogin.tsx
+++ b/src/login/ClientLogin.tsx
@@ -8,11 +8,8 @@ import {
   clearExecutorPublicKey,
   getAppEndpointKey,
   getApplicationId,
-  setAccessToken,
-  setApplicationId,
   setContextId,
   setExecutorPublicKey,
-  setRefreshToken,
 } from '../storage/storage';
 import {
   ErrorMessage,
@@ -157,30 +154,6 @@ export const ClientLogin: React.FC<ClientLoginProps> = ({
       applicationPath: clientApplicationPath,
     });
   }, [nodeServerUrl, permissions, clientApplicationId, clientApplicationPath]);
-
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const encodedAccessToken = urlParams.get('access_token');
-    const encodedRefreshToken = urlParams.get('refresh_token');
-
-    if (encodedAccessToken && encodedRefreshToken) {
-      const accessToken = decodeURIComponent(encodedAccessToken);
-      const refreshToken = decodeURIComponent(encodedRefreshToken);
-      setAccessToken(accessToken);
-      setRefreshToken(refreshToken);
-      if (clientApplicationId) {
-        setApplicationId(clientApplicationId);
-        setIsAuthenticated(true);
-      } else {
-        fetchContextApplication();
-      }
-    }
-  }, [
-    nodeServerUrl,
-    clientApplicationId,
-    setIsAuthenticated,
-    fetchContextApplication,
-  ]);
 
   useEffect(() => {
     if (authMode === false) {

--- a/src/login/ProtectedRoutesWrapper.tsx
+++ b/src/login/ProtectedRoutesWrapper.tsx
@@ -243,10 +243,14 @@ export const ProtectedRoutesWrapper: React.FC<ProtectedRoutesWrapperProps> = ({
   }, [authMode, error]);
 
   useEffect(() => {
-    // Check for tokens in URL
-    const urlParams = new URLSearchParams(window.location.search);
-    const encodedAccessToken = urlParams.get('access_token');
-    const encodedRefreshToken = urlParams.get('refresh_token');
+    // Check for tokens in URL fragment
+    const fragment = window.location.hash.substring(1); // Remove the leading #
+    const fragmentParams = new URLSearchParams(fragment);
+    const encodedAccessToken = fragmentParams.get('access_token');
+    const encodedRefreshToken = fragmentParams.get('refresh_token');
+
+    console.log('encodedAccessToken', encodedAccessToken);
+    console.log('encodedRefreshToken', encodedRefreshToken);
 
     if (encodedAccessToken && encodedRefreshToken) {
       // Initialize application with tokens and optional applicationId
@@ -260,13 +264,15 @@ export const ProtectedRoutesWrapper: React.FC<ProtectedRoutesWrapperProps> = ({
         applicationId || undefined,
       );
 
-      // Clean up URL by removing the tokens
-      urlParams.delete('access_token');
-      urlParams.delete('refresh_token');
-      const newUrl =
-        window.location.pathname +
-        (urlParams.toString() ? `?${urlParams.toString()}` : '');
+      // Clean up URL by removing the tokens from fragment
+      fragmentParams.delete('access_token');
+      fragmentParams.delete('refresh_token');
+      const newFragment = fragmentParams.toString();
+      const newUrl = window.location.pathname + window.location.search + 
+        (newFragment ? `#${newFragment}` : '');
       window.history.replaceState({}, '', newUrl);
+      setIsAuthenticated(true);
+      setIsInitialized(true);
     } else {
       checkAuth();
     }

--- a/src/login/ProtectedRoutesWrapper.tsx
+++ b/src/login/ProtectedRoutesWrapper.tsx
@@ -268,7 +268,9 @@ export const ProtectedRoutesWrapper: React.FC<ProtectedRoutesWrapperProps> = ({
       fragmentParams.delete('access_token');
       fragmentParams.delete('refresh_token');
       const newFragment = fragmentParams.toString();
-      const newUrl = window.location.pathname + window.location.search + 
+      const newUrl =
+        window.location.pathname +
+        window.location.search +
         (newFragment ? `#${newFragment}` : '');
       window.history.replaceState({}, '', newUrl);
       setIsAuthenticated(true);


### PR DESCRIPTION
Blob handlers are now using httpClient instead of having its own logic.
Changed access and refresh token to be received as URL fragments instead of URL params, both in old implementation and experimental