### PR TITLE
feat: add new websocket api

### DIFF
--- a/example/src/EventLog.css
+++ b/example/src/EventLog.css
@@ -131,4 +131,4 @@
   background-color: #e9ecef;
   padding: 0.5rem;
   border-radius: 4px;
-} 
+}

--- a/example/src/EventLog.css
+++ b/example/src/EventLog.css
@@ -1,0 +1,134 @@
+.event-log-container {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+  margin-top: 1.5rem;
+  overflow: hidden;
+}
+
+.event-log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background-color: #f1f1f1;
+  border-bottom: 1px solid #ddd;
+}
+
+.event-log-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.event-log-header button {
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s;
+}
+
+.event-log-header button:hover {
+  background-color: #5a6268;
+}
+
+.event-log-header button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.event-log-content {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.event-log-placeholder {
+  text-align: center;
+  color: #888;
+  padding: 2rem;
+  font-style: italic;
+}
+
+.event-item-container {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  background-color: #fff;
+}
+
+.event-item-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.6rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+}
+
+.event-item-header:hover {
+  background-color: #f5f5f5;
+}
+
+.event-caret {
+  font-family: monospace;
+  transition: transform 0.2s;
+}
+
+.event-caret.open {
+  transform: rotate(90deg);
+}
+
+.event-timestamp {
+  font-weight: 500;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.event-type-badge {
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: white;
+  text-transform: capitalize;
+}
+
+.event-type-badge.StateMutation {
+  background-color: #007bff;
+}
+
+.event-type-badge.ExecutionEvent {
+  background-color: #28a745;
+}
+
+.event-context-id {
+  font-family: monospace;
+  color: #888;
+  font-size: 0.85rem;
+}
+
+.event-item-body {
+  padding: 0.75rem;
+  background-color: #fafafa;
+  border-top: 1px solid #eee;
+}
+
+.event-item-body pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.85rem;
+  background-color: #e9ecef;
+  padding: 0.5rem;
+  border-radius: 4px;
+} 

--- a/example/src/EventLog.tsx
+++ b/example/src/EventLog.tsx
@@ -16,9 +16,14 @@ const EventItem: React.FC<EventItemProps> = ({ event }) => {
 
   return (
     <div className="event-item-container">
-      <button className="event-item-header" onClick={() => setIsCollapsed(!isCollapsed)}>
+      <button
+        className="event-item-header"
+        onClick={() => setIsCollapsed(!isCollapsed)}
+      >
         <span className={`event-caret ${isCollapsed ? '' : 'open'}`}>▶</span>
-        <span className="event-timestamp">{new Date().toLocaleTimeString()}</span>
+        <span className="event-timestamp">
+          {new Date().toLocaleTimeString()}
+        </span>
         <span className={`event-type-badge ${event.type}`}>{event.type}</span>
         <span className="event-context-id" title={event.contextId}>
           {event.contextId.substring(0, 15)}...
@@ -44,15 +49,19 @@ const EventLog: React.FC<EventLogProps> = ({ events, onClear }) => {
       </div>
       <div className="event-log-content">
         {events.length === 0 ? (
-          <p className="event-log-placeholder">Subscribe to see live events here...</p>
+          <p className="event-log-placeholder">
+            Subscribe to see live events here...
+          </p>
         ) : (
-          [...events].reverse().map((event, index) => (
-            <EventItem key={`${event.contextId}-${index}`} event={event} />
-          ))
+          [...events]
+            .reverse()
+            .map((event, index) => (
+              <EventItem key={`${event.contextId}-${index}`} event={event} />
+            ))
         )}
       </div>
     </div>
   );
 };
 
-export default EventLog; 
+export default EventLog;

--- a/example/src/EventLog.tsx
+++ b/example/src/EventLog.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { SubscriptionEvent } from '@calimero-network/calimero-client';
+import './EventLog.css';
+
+interface EventLogProps {
+  events: SubscriptionEvent[];
+  onClear: () => void;
+}
+
+interface EventItemProps {
+  event: SubscriptionEvent;
+}
+
+const EventItem: React.FC<EventItemProps> = ({ event }) => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  return (
+    <div className="event-item-container">
+      <button className="event-item-header" onClick={() => setIsCollapsed(!isCollapsed)}>
+        <span className={`event-caret ${isCollapsed ? '' : 'open'}`}>▶</span>
+        <span className="event-timestamp">{new Date().toLocaleTimeString()}</span>
+        <span className={`event-type-badge ${event.type}`}>{event.type}</span>
+        <span className="event-context-id" title={event.contextId}>
+          {event.contextId.substring(0, 15)}...
+        </span>
+      </button>
+      {!isCollapsed && (
+        <div className="event-item-body">
+          <pre>{JSON.stringify(event, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const EventLog: React.FC<EventLogProps> = ({ events, onClear }) => {
+  return (
+    <div className="event-log-container">
+      <div className="event-log-header">
+        <h3>Live Event Log</h3>
+        <button onClick={onClear} disabled={events.length === 0}>
+          Clear Log
+        </button>
+      </div>
+      <div className="event-log-content">
+        {events.length === 0 ? (
+          <p className="event-log-placeholder">Subscribe to see live events here...</p>
+        ) : (
+          [...events].reverse().map((event, index) => (
+            <EventItem key={`${event.contextId}-${index}`} event={event} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EventLog; 

--- a/example/src/ExecutionModal.css
+++ b/example/src/ExecutionModal.css
@@ -1,50 +1,266 @@
-.execution-modal-content {
-  text-align: left;
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
 }
 
-.execution-modal-content h2 {
-  margin-top: 0;
-  margin-bottom: 2rem;
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 0;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #f8f9fa;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #333;
+}
+
+.close-button {
+  background: none;
+  border: none;
   font-size: 1.5rem;
-  color: var(--text-color);
+  cursor: pointer;
+  color: #666;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.close-button:hover {
+  background-color: #e0e0e0;
+  color: #333;
+}
+
+.modal-body {
+  padding: 1rem;
+  max-height: calc(80vh - 80px);
+  overflow-y: auto;
 }
 
 .form-group {
   margin-bottom: 1rem;
-  display: flex;
-  flex-direction: column;
 }
 
 .form-group label {
+  display: block;
   margin-bottom: 0.5rem;
-  font-weight: bold;
-  color: var(--text-secondary-color);
+  font-weight: 500;
+  color: #333;
 }
 
-.form-group select,
-.form-group input {
-  padding: 0.75rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background-color: var(--background-input);
-  color: var(--text-color-input);
-  font-size: 1rem;
-  transition:
-    border-color 0.3s,
-    box-shadow 0.3s;
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
 }
 
-.form-group select:focus,
-.form-group input:focus {
-  border-color: var(--accent-color);
-  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.2);
-  outline: none;
+.form-group textarea {
+  min-height: 100px;
+  resize: vertical;
+  font-family: monospace;
 }
 
-.execution-modal-content .button-group {
-  margin-top: 1.5rem;
+.button-group {
+  display: flex;
+  gap: 0.5rem;
   justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.execute-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.execute-button:hover {
+  background-color: #0056b3;
+}
+
+.execute-button:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+.cancel-button {
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.cancel-button:hover {
+  background-color: #545b62;
+}
+
+/* Subscription Modal Styles */
+.subscription-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.subscribe-button {
+  background-color: #28a745;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.subscribe-button:hover {
+  background-color: #218838;
+}
+
+.subscribe-button:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+.unsubscribe-button {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.unsubscribe-button:hover {
+  background-color: #c82333;
+}
+
+.clear-button {
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.clear-button:hover {
+  background-color: #545b62;
+}
+
+.error-message {
+  background-color: #f8d7da;
+  color: #721c24;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  border: 1px solid #f5c6cb;
+}
+
+.events-container {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1rem;
+  background-color: #f8f9fa;
+}
+
+.events-container h3 {
+  margin: 0 0 1rem 0;
+  color: #333;
+  font-size: 1.1rem;
+}
+
+.no-events {
+  color: #666;
+  font-style: italic;
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.events-list {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.event-item {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+}
+
+.event-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem;
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.event-type {
+  font-weight: 600;
+  color: #333;
+  padding: 0.25rem 0.5rem;
+  background-color: #e9ecef;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.event-time {
+  color: #666;
+  font-size: 0.8rem;
+}
+
+.event-data {
+  padding: 0.5rem;
+}
+
+.event-data pre {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #333;
+  background-color: #f8f9fa;
+  padding: 0.5rem;
+  border-radius: 3px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/example/src/ExecutionModal.tsx
+++ b/example/src/ExecutionModal.tsx
@@ -57,18 +57,25 @@ const ExecutionModal: React.FC<ExecutionModalProps> = ({
   };
 
   return (
-    <div className="overlay-backdrop" onClick={onClose}>
+    <div className="modal-overlay" onClick={onClose}>
       <div
-        className="overlay-content execution-modal-content"
+        className="modal-content"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2>Execute method on context: {context.contextId}</h2>
+        <div className="modal-header">
+          <h2>Execute method on context: {context.contextId}</h2>
+          <button className="close-button" onClick={onClose}>
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
         <div className="form-group">
           <label htmlFor="method-select">Method</label>
           <select
             id="method-select"
             value={selectedMethod}
             onChange={(e) => setSelectedMethod(e.target.value)}
+            style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px', fontSize: '0.9rem' }}
           >
             {METHODS.map((method) => (
               <option key={method.name} value={method.name}>
@@ -92,12 +99,21 @@ const ExecutionModal: React.FC<ExecutionModalProps> = ({
         ))}
 
         <div className="button-group">
-          <button onClick={handleExecute} disabled={isExecuting}>
+          <button 
+            className="execute-button" 
+            onClick={handleExecute} 
+            disabled={isExecuting}
+          >
             {isExecuting ? 'Executing...' : 'Execute'}
           </button>
-          <button onClick={onClose} disabled={isExecuting}>
+          <button 
+            className="cancel-button" 
+            onClick={onClose} 
+            disabled={isExecuting}
+          >
             Cancel
           </button>
+        </div>
         </div>
       </div>
     </div>

--- a/example/src/ExecutionModal.tsx
+++ b/example/src/ExecutionModal.tsx
@@ -58,10 +58,7 @@ const ExecutionModal: React.FC<ExecutionModalProps> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div
-        className="modal-content"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2>Execute method on context: {context.contextId}</h2>
           <button className="close-button" onClick={onClose}>
@@ -69,51 +66,57 @@ const ExecutionModal: React.FC<ExecutionModalProps> = ({
           </button>
         </div>
         <div className="modal-body">
-        <div className="form-group">
-          <label htmlFor="method-select">Method</label>
-          <select
-            id="method-select"
-            value={selectedMethod}
-            onChange={(e) => setSelectedMethod(e.target.value)}
-            style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px', fontSize: '0.9rem' }}
-          >
-            {METHODS.map((method) => (
-              <option key={method.name} value={method.name}>
-                {method.name}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {currentMethod?.args.map((argName) => (
-          <div className="form-group" key={argName}>
-            <label htmlFor={`arg-${argName}`}>{argName}</label>
-            <input
-              type="text"
-              id={`arg-${argName}`}
-              name={argName}
-              value={args[argName] || ''}
-              onChange={handleArgChange}
-            />
+          <div className="form-group">
+            <label htmlFor="method-select">Method</label>
+            <select
+              id="method-select"
+              value={selectedMethod}
+              onChange={(e) => setSelectedMethod(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                fontSize: '0.9rem',
+              }}
+            >
+              {METHODS.map((method) => (
+                <option key={method.name} value={method.name}>
+                  {method.name}
+                </option>
+              ))}
+            </select>
           </div>
-        ))}
 
-        <div className="button-group">
-          <button 
-            className="execute-button" 
-            onClick={handleExecute} 
-            disabled={isExecuting}
-          >
-            {isExecuting ? 'Executing...' : 'Execute'}
-          </button>
-          <button 
-            className="cancel-button" 
-            onClick={onClose} 
-            disabled={isExecuting}
-          >
-            Cancel
-          </button>
-        </div>
+          {currentMethod?.args.map((argName) => (
+            <div className="form-group" key={argName}>
+              <label htmlFor={`arg-${argName}`}>{argName}</label>
+              <input
+                type="text"
+                id={`arg-${argName}`}
+                name={argName}
+                value={args[argName] || ''}
+                onChange={handleArgChange}
+              />
+            </div>
+          ))}
+
+          <div className="button-group">
+            <button
+              className="execute-button"
+              onClick={handleExecute}
+              disabled={isExecuting}
+            >
+              {isExecuting ? 'Executing...' : 'Execute'}
+            </button>
+            <button
+              className="cancel-button"
+              onClick={onClose}
+              disabled={isExecuting}
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -8,8 +8,10 @@ import {
   Context,
   ExecutionResponse,
   AppMode,
+  SubscriptionEvent,
 } from '@calimero-network/calimero-client';
 import ExecutionModal from './ExecutionModal';
+import EventLog from './EventLog';
 
 const AppContent: React.FC = () => {
   const { isAuthenticated, app } = useCalimero();
@@ -18,6 +20,10 @@ const AppContent: React.FC = () => {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedContext, setSelectedContext] = useState<Context | null>(null);
+  const [subscribedContexts, setSubscribedContexts] = useState<Set<string>>(
+    new Set(),
+  );
+  const [events, setEvents] = useState<SubscriptionEvent[]>([]);
 
   const fetchContexts = useCallback(async () => {
     if (app) {
@@ -52,9 +58,48 @@ const AppContent: React.FC = () => {
     }
   };
 
+  const eventCallback = useCallback((event: SubscriptionEvent) => {
+    setEvents((prevEvents) => [event, ...prevEvents]);
+  }, []);
+
+  const handleToggleSubscription = useCallback(
+    async (contextId: string) => {
+      if (!app) return;
+      const newSubscribed = new Set(subscribedContexts);
+      const isSubscribed = newSubscribed.has(contextId);
+
+      if (isSubscribed) {
+        newSubscribed.delete(contextId);
+        app.unsubscribeFromEvents([contextId]);
+      } else {
+        newSubscribed.add(contextId);
+        app.subscribeToEvents([contextId], eventCallback);
+      }
+      setSubscribedContexts(newSubscribed);
+    },
+    [app, subscribedContexts, eventCallback],
+  );
+
+  const handleToggleAllSubscriptions = useCallback(async () => {
+    if (!app || contexts.length === 0) return;
+    const allContextIds = contexts.map((c) => c.contextId);
+    const allCurrentlySubscribed = subscribedContexts.size === contexts.length;
+
+    if (allCurrentlySubscribed) {
+      app.unsubscribeFromEvents(allContextIds);
+      setSubscribedContexts(new Set());
+    } else {
+      app.subscribeToEvents(allContextIds, eventCallback);
+      setSubscribedContexts(new Set(allContextIds));
+    }
+  }, [app, contexts, subscribedContexts, eventCallback]);
+
   const handleExecute = (response: ExecutionResponse) => {
     console.log('Execution Result:', response);
   };
+
+  const areAllSubscribed =
+    contexts.length > 0 && subscribedContexts.size === contexts.length;
 
   return (
     <div>
@@ -93,9 +138,21 @@ const AppContent: React.FC = () => {
               }}
             >
               <h2>Available Contexts:</h2>
-              <button onClick={handleCreateContext} disabled={creating}>
-                {creating ? 'Creating...' : 'Create New Context'}
-              </button>
+              <div>
+                <button
+                  onClick={handleToggleAllSubscriptions}
+                  disabled={contexts.length === 0}
+                  className={
+                    areAllSubscribed ? 'unsubscribe-button' : 'subscribe-button'
+                  }
+                  style={{ marginRight: '1rem' }}
+                >
+                  {areAllSubscribed ? 'Unsubscribe from All' : 'Subscribe to All'}
+                </button>
+                <button onClick={handleCreateContext} disabled={creating}>
+                  {creating ? 'Creating...' : 'Create New Context'}
+                </button>
+              </div>
             </div>
             {loading && <p>Loading contexts...</p>}
             {error && <p style={{ color: 'red' }}>Error: {error}</p>}
@@ -104,16 +161,52 @@ const AppContent: React.FC = () => {
                 {contexts.map((ctx) => (
                   <li
                     key={ctx.contextId}
-                    onClick={() => setSelectedContext(ctx)}
-                    style={{ cursor: 'pointer', marginBottom: '0.5rem' }}
+                    style={{
+                      cursor: 'pointer',
+                      marginBottom: '0.5rem',
+                      padding: '0.5rem',
+                      border: '1px solid #ccc',
+                      borderRadius: '4px',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
                   >
-                    Context ID: {ctx.contextId}
+                    <span>Context ID: {ctx.contextId}</span>
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      <button
+                        onClick={() => handleToggleSubscription(ctx.contextId)}
+                        className={
+                          subscribedContexts.has(ctx.contextId)
+                            ? 'unsubscribe-button'
+                            : 'subscribe-button'
+                        }
+                        style={{
+                          padding: '0.25rem 0.5rem',
+                          fontSize: '0.8rem',
+                        }}
+                      >
+                        {subscribedContexts.has(ctx.contextId)
+                          ? 'Unsubscribe'
+                          : 'Subscribe'}
+                      </button>
+                      <button
+                        onClick={() => setSelectedContext(ctx)}
+                        style={{
+                          padding: '0.25rem 0.5rem',
+                          fontSize: '0.8rem',
+                        }}
+                      >
+                        Execute
+                      </button>
+                    </div>
                   </li>
                 ))}
               </ul>
             ) : (
               !loading && <p>No contexts found.</p>
             )}
+            <EventLog events={events} onClear={() => setEvents([])} />
           </div>
         ) : (
           <p>Please connect to see your contexts.</p>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -147,7 +147,9 @@ const AppContent: React.FC = () => {
                   }
                   style={{ marginRight: '1rem' }}
                 >
-                  {areAllSubscribed ? 'Unsubscribe from All' : 'Subscribe to All'}
+                  {areAllSubscribed
+                    ? 'Unsubscribe from All'
+                    : 'Subscribe to All'}
                 </button>
                 <button onClick={handleCreateContext} disabled={creating}>
                   {creating ? 'Creating...' : 'Create New Context'}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "styled-components": "^6.1.13"
   },
   "scripts": {
-    "build": "tsc && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=esm --outfile=lib/index.mjs --define:__PROTOCOL_VERSION__='\"'$npm_package_version'\"' --external:react --external:react-dom --external:styled-components && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=cjs --outfile=lib/index.js --define:__PROTOCOL_VERSION__='\"'$npm_package_version'\"' --external:react --external:react-dom --external:styled-components",
+    "build": "tsc && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=esm --outfile=lib/index.mjs --external:react --external:react-dom --external:styled-components && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=cjs --outfile=lib/index.js --external:react --external:react-dom --external:styled-components",
     "test": "jest test",
     "lint": "eslint . --ext .ts,.tsx src",
     "dev": "concurrently \"pnpm compile -w\" \"pnpm bundle:watch\"",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "styled-components": "^6.1.13"
   },
   "scripts": {
-    "build": "tsc && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=esm --outfile=lib/index.mjs --external:react --external:react-dom --external:styled-components && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=cjs --outfile=lib/index.js --external:react --external:react-dom --external:styled-components",
+    "build": "tsc && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=esm --outfile=lib/index.mjs --define:__PROTOCOL_VERSION__='\"'$npm_package_version'\"' --external:react --external:react-dom --external:styled-components && esbuild src/index.ts --bundle --platform=browser --target=es2020 --format=cjs --outfile=lib/index.js --define:__PROTOCOL_VERSION__='\"'$npm_package_version'\"' --external:react --external:react-dom --external:styled-components",
     "test": "jest test",
     "lint": "eslint . --ext .ts,.tsx src",
     "dev": "concurrently \"pnpm compile -w\" \"pnpm bundle:watch\"",

--- a/src/experimental/CalimeroProvider.tsx
+++ b/src/experimental/CalimeroProvider.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useMemo,
 } from 'react';
 import { apiClient } from '../api';
 import {
@@ -190,10 +191,21 @@ export const CalimeroProvider: React.FC<CalimeroProviderProps> = ({
   };
 
   const login = () => setIsLoginOpen(true);
-  const app =
-    isAuthenticated && isOnline
-      ? new CalimeroApplication(apiClient, clientApplicationId)
-      : null;
+
+  const app = useMemo(
+    () =>
+      isAuthenticated
+        ? new CalimeroApplication(apiClient, clientApplicationId)
+        : null,
+    [isAuthenticated, clientApplicationId],
+  );
+
+  useEffect(() => {
+    // Closes WebSocket connection on logout or when the component unmounts
+    return () => {
+      app?.close();
+    };
+  }, [app]);
 
   return (
     <CalimeroContext.Provider

--- a/src/experimental/app.ts
+++ b/src/experimental/app.ts
@@ -19,7 +19,7 @@ export class CalimeroApplication implements CalimeroApp {
   constructor(apiClient: ApiClient, clientApplicationId: string) {
     this.apiClient = apiClient;
     this.clientApplicationId = clientApplicationId;
-    const baseUrl = getAppEndpointKey() || 'calimero-only-peers-dev.s3.amazonaws.com';
+    const baseUrl = getAppEndpointKey();
     this.websocket = new ExperimentalWebSocket(baseUrl);
   }
 

--- a/src/experimental/types.ts
+++ b/src/experimental/types.ts
@@ -26,6 +26,13 @@ export interface ExecutionResponse {
   error?: string;
 }
 
+// Subscription event types
+export interface SubscriptionEvent {
+  contextId: string;
+  type: 'StateMutation' | 'ExecutionEvent';
+  data: any;
+}
+
 // Interface for the application client
 export interface CalimeroApp {
   /**
@@ -60,4 +67,25 @@ export interface CalimeroApp {
    * @param context - The context to delete.
    */
   deleteContext(context: Context): Promise<void>;
+
+  /**
+   * Subscribes to events for specific contexts.
+   * @param contextIds - Array of context IDs to subscribe to.
+   * @param callback - Function to call when events are received.
+   */
+  subscribeToEvents(
+    contextIds: string[],
+    callback: (event: SubscriptionEvent) => void,
+  ): void;
+
+  /**
+   * Unsubscribes from events for specific contexts.
+   * @param contextIds - Array of context IDs to unsubscribe from.
+   */
+  unsubscribeFromEvents(contextIds: string[]): void;
+
+  /**
+   * Closes the underlying WebSocket connection.
+   */
+  close(): void;
 }

--- a/src/experimental/websocket.ts
+++ b/src/experimental/websocket.ts
@@ -2,8 +2,6 @@ import { getAccessToken } from '../storage/storage';
 import { NodeEvent } from '../subscriptions';
 
 const RECONNECT_DELAY = 5000; // 5 seconds
-const PROTOCOL_NAME = 'calimero-client';
-declare const __PROTOCOL_VERSION__: string; // injected by the build process
 
 type WsCallback = (event: NodeEvent) => void;
 
@@ -38,10 +36,10 @@ export class ExperimentalWebSocket {
       return;
     }
 
-    const protocol = [`${PROTOCOL_NAME}-v${__PROTOCOL_VERSION__}`, accessToken]; // Smuggle token
-    console.log('Connecting to Experimental WebSocket:', this.url);
+    const fullUrl = `${this.url}?token=${encodeURIComponent(accessToken)}`;
+    console.log('Connecting to Experimental WebSocket:', fullUrl);
 
-    this.ws = new WebSocket(this.url, protocol);
+    this.ws = new WebSocket(fullUrl);
 
     this.ws.onopen = () => {
       console.log('Experimental WebSocket connected.');

--- a/src/experimental/websocket.ts
+++ b/src/experimental/websocket.ts
@@ -3,7 +3,7 @@ import { NodeEvent } from '../subscriptions';
 
 const RECONNECT_DELAY = 5000; // 5 seconds
 const PROTOCOL_NAME = 'calimero-client';
-const PROTOCOL_VERSION = '0.1.11';
+declare const __PROTOCOL_VERSION__: string; // injected by the build process
 
 type WsCallback = (event: NodeEvent) => void;
 
@@ -38,11 +38,10 @@ export class ExperimentalWebSocket {
       return;
     }
 
-    const fullUrl = this.url; // Token is no longer in the URL
-    const protocol = [`${PROTOCOL_NAME}-v${PROTOCOL_VERSION}`, accessToken]; // Smuggle token
-    console.log('Connecting to Experimental WebSocket:', fullUrl);
+    const protocol = [`${PROTOCOL_NAME}-v${__PROTOCOL_VERSION__}`, accessToken]; // Smuggle token
+    console.log('Connecting to Experimental WebSocket:', this.url);
 
-    this.ws = new WebSocket(fullUrl, protocol);
+    this.ws = new WebSocket(this.url, protocol);
 
     this.ws.onopen = () => {
       console.log('Experimental WebSocket connected.');
@@ -75,7 +74,7 @@ export class ExperimentalWebSocket {
       this.ws?.close();
     };
   }
-  
+
   private decodeEventData(nodeEvent: NodeEvent): void {
     if (
       nodeEvent.type === 'ExecutionEvent' &&
@@ -125,13 +124,15 @@ export class ExperimentalWebSocket {
     contextIds.forEach((contextId) => {
       this.callbacks.set(contextId, callback);
     });
-    
+
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
-        id: this.requestId++,
-        method: 'subscribe',
-        params: { contextIds: contextIds }
-      }));
+      this.ws.send(
+        JSON.stringify({
+          id: this.requestId++,
+          method: 'subscribe',
+          params: { contextIds: contextIds },
+        }),
+      );
     }
   }
 
@@ -141,11 +142,13 @@ export class ExperimentalWebSocket {
     });
 
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
-        id: this.requestId++,
-        method: 'unsubscribe',
-        params: { contextIds: contextIds }
-      }));
+      this.ws.send(
+        JSON.stringify({
+          id: this.requestId++,
+          method: 'unsubscribe',
+          params: { contextIds: contextIds },
+        }),
+      );
     }
   }
 
@@ -153,4 +156,4 @@ export class ExperimentalWebSocket {
     this.clearReconnect();
     this.ws?.close();
   }
-} 
+}

--- a/src/experimental/websocket.ts
+++ b/src/experimental/websocket.ts
@@ -1,0 +1,153 @@
+import { getAccessToken } from '../storage/storage';
+import { NodeEvent } from '../subscriptions';
+
+const RECONNECT_DELAY = 5000; // 5 seconds
+
+type WsCallback = (event: NodeEvent) => void;
+
+export class ExperimentalWebSocket {
+  private ws: WebSocket | null = null;
+  private url: string;
+  private reconnectTimeout: NodeJS.Timeout | null = null;
+  private callbacks: Map<string, WsCallback> = new Map();
+  private requestId = 0;
+
+  constructor(baseUrl: string) {
+    this.url = this.buildUrl(baseUrl);
+    this.connect();
+  }
+
+  private buildUrl(baseUrl: string): string {
+    let wsUrl = '';
+    if (baseUrl.startsWith('https://')) {
+      wsUrl = baseUrl.replace('https://', 'wss://');
+    } else if (baseUrl.startsWith('http://')) {
+      wsUrl = baseUrl.replace('http://', 'ws://');
+    } else {
+      wsUrl = `wss://${baseUrl}`;
+    }
+    return `${wsUrl}/ws`;
+  }
+
+  private connect(): void {
+    const accessToken = getAccessToken();
+    if (!accessToken) {
+      console.warn('No access token found, WebSocket connection aborted.');
+      return;
+    }
+
+    const fullUrl = `${this.url}?token=${encodeURIComponent(accessToken)}`;
+    console.log('Connecting to Experimental WebSocket:', fullUrl);
+
+    this.ws = new WebSocket(fullUrl);
+
+    this.ws.onopen = () => {
+      console.log('Experimental WebSocket connected.');
+      this.clearReconnect();
+    };
+
+    this.ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.result && data.result.contextId) {
+          const nodeEvent: NodeEvent = data.result;
+          this.decodeEventData(nodeEvent);
+          const callback = this.callbacks.get(nodeEvent.contextId);
+          if (callback) {
+            callback(nodeEvent);
+          }
+        }
+      } catch (e) {
+        console.error('Error parsing WebSocket message:', e);
+      }
+    };
+
+    this.ws.onclose = () => {
+      console.log('Experimental WebSocket disconnected.');
+      this.scheduleReconnect();
+    };
+
+    this.ws.onerror = (error) => {
+      console.error('Experimental WebSocket error:', error);
+      this.ws?.close();
+    };
+  }
+  
+  private decodeEventData(nodeEvent: NodeEvent): void {
+    if (
+      nodeEvent.type === 'ExecutionEvent' &&
+      nodeEvent.data &&
+      Array.isArray(nodeEvent.data.events)
+    ) {
+      nodeEvent.data.events.forEach((executionEvent) => {
+        if (
+          Array.isArray(executionEvent.data) &&
+          executionEvent.data.every((item) => typeof item === 'number')
+        ) {
+          try {
+            const decodedString = new TextDecoder().decode(
+              new Uint8Array(executionEvent.data),
+            );
+            try {
+              executionEvent.data = JSON.parse(decodedString);
+            } catch (jsonError) {
+              executionEvent.data = decodedString;
+            }
+          } catch (decodeError) {
+            console.error(
+              'Failed to decode event data byte array',
+              decodeError,
+            );
+          }
+        }
+      });
+    }
+  }
+
+  private scheduleReconnect(): void {
+    this.clearReconnect();
+    this.reconnectTimeout = setTimeout(() => {
+      console.log('Attempting to reconnect WebSocket...');
+      this.connect();
+    }, RECONNECT_DELAY);
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+    }
+  }
+
+  public subscribe(contextIds: string[], callback: WsCallback): void {
+    contextIds.forEach((contextId) => {
+      this.callbacks.set(contextId, callback);
+    });
+    
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        id: this.requestId++,
+        method: 'subscribe',
+        params: { contextIds: contextIds }
+      }));
+    }
+  }
+
+  public unsubscribe(contextIds: string[]): void {
+    contextIds.forEach((contextId) => {
+      this.callbacks.delete(contextId);
+    });
+
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        id: this.requestId++,
+        method: 'unsubscribe',
+        params: { contextIds: contextIds }
+      }));
+    }
+  }
+
+  public close(): void {
+    this.clearReconnect();
+    this.ws?.close();
+  }
+} 

--- a/src/experimental/websocket.ts
+++ b/src/experimental/websocket.ts
@@ -2,6 +2,8 @@ import { getAccessToken } from '../storage/storage';
 import { NodeEvent } from '../subscriptions';
 
 const RECONNECT_DELAY = 5000; // 5 seconds
+const PROTOCOL_NAME = 'calimero-client';
+const PROTOCOL_VERSION = '0.1.11';
 
 type WsCallback = (event: NodeEvent) => void;
 
@@ -36,10 +38,11 @@ export class ExperimentalWebSocket {
       return;
     }
 
-    const fullUrl = `${this.url}?token=${encodeURIComponent(accessToken)}`;
+    const fullUrl = this.url; // Token is no longer in the URL
+    const protocol = [`${PROTOCOL_NAME}-v${PROTOCOL_VERSION}`, accessToken]; // Smuggle token
     console.log('Connecting to Experimental WebSocket:', fullUrl);
 
-    this.ws = new WebSocket(fullUrl);
+    this.ws = new WebSocket(fullUrl, protocol);
 
     this.ws.onopen = () => {
       console.log('Experimental WebSocket connected.');


### PR DESCRIPTION
This pull request introduces a new WebSocket client in the `experimental` module to handle real-time event subscriptions. The new implementation is isolated from the existing subscription service to ensure backward compatibility.

#### Key Changes:

*   **New WebSocket Client (`src/experimental/websocket.ts`):**
    *   Adds a new, self-managing WebSocket client that automatically connects on instantiation and reconnects with a 5-second delay if the connection is lost.

*   **Authentication:**
    *   Implements JWT authentication by passing the token as a `token` **URL query parameter**.

*   **Event Handling:**
    *   Implements a central dispatcher in `CalimeroApplication` to prevent duplicate event processing when multiple contexts are subscribed.
    *   The `subscribeToEvents` and `unsubscribeFromEvents` methods now accept an array of context IDs to perform batch operations in a single WebSocket message.
    *   `ExecutionEvent` data is now decoded from a byte array into JSON on the client.

*   **Performance:**
    *   The `CalimeroApplication` instance in `CalimeroProvider` is now memoized. This resolves a critical bug that was causing excessive API calls and dropped subscription callbacks by preventing the instance from being recreated on network health checks.

*   **Example Application:**
    *   The example has been significantly updated to use the new client, featuring a real-time event log and controls for both individual and batch context subscriptions to serve as a powerful debugging tool.

https://github.com/user-attachments/assets/1f6093ef-2718-4de8-bf8d-2095d07a76cc

