### PR TITLE
feat: add automatic hash param for node url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-network/calimero-client",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/src/setup/SetupModal.tsx
+++ b/src/setup/SetupModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useCallback, useState } from 'react';
 
 import Spinner from '../components/loader/Spinner';
@@ -109,6 +109,24 @@ export const SetupModal: React.FC<SetupModalProps> = ({ setNodeServerUrl }) => {
   };
 
   const isSubmitDisabled = !url || Boolean(errors.url);
+
+  useEffect(() => {
+    const fragment = window.location.hash.substring(1);
+    const fragmentParams = new URLSearchParams(fragment);
+    const nodeUrl = fragmentParams.get('node_url');
+
+    if (nodeUrl) {
+      handleUrlChange(decodeURIComponent(nodeUrl));
+
+      fragmentParams.delete('node_url');
+      const newFragment = fragmentParams.toString();
+      const newUrl =
+        window.location.pathname +
+        window.location.search +
+        (newFragment ? `#${newFragment}` : '');
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, []);
 
   return (
     <SetupModalOverlay>


### PR DESCRIPTION
# feat: add automatic hash param for node url

## Description
When redirecting from apps like Node Console we redirect to admin dashboard url with hash param in URL so input field in Setup modal gets filled on page load.