### PR TITLE
feat: fix blob download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-network/calimero-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/src/api/blobApi.ts
+++ b/src/api/blobApi.ts
@@ -43,7 +43,7 @@ export interface BlobApi {
     onProgress?: (progress: number) => void,
     expectedHash?: string,
   ): ApiResponse<BlobUploadResponse>;
-  downloadBlob(blobId: string): Promise<Blob>;
+  downloadBlob(blobId: string, contextId: string): Promise<Blob>;
   getBlobMetadata(blobId: string): ApiResponse<BlobMetadataResponse>;
   listBlobs(): ApiResponse<BlobListResponseData>;
   deleteBlob(blobId: string): ApiResponse<void>;

--- a/src/api/dataSource/BlobApiDataSource.ts
+++ b/src/api/dataSource/BlobApiDataSource.ts
@@ -8,7 +8,7 @@ import {
   BlobListResponseData,
   RawBlobListResponseData,
 } from '../blobApi';
-import { getAppEndpointKey, getContextId } from '../../storage';
+import { getAppEndpointKey } from '../../storage';
 
 export class BlobApiDataSource implements BlobApi {
   constructor(private client: HttpClient) {}
@@ -72,11 +72,11 @@ export class BlobApiDataSource implements BlobApi {
     }
   }
 
-  async downloadBlob(blobId: string): Promise<Blob> {
+  async downloadBlob(blobId: string, contextId: string): Promise<Blob> {
     let url = `${this.baseUrl}/admin-api/blobs/${blobId}`;
 
     const params = new URLSearchParams();
-    params.append('context_id', getContextId());
+    params.append('context_id', contextId);
     if (params.toString()) {
       url += `?${params.toString()}`;
     }


### PR DESCRIPTION
# feat: fix blob download

## Description 
Using  `getContextId()` is going to work with 1 context simple applications and not with complex multi context applications. 
LocalStorage context id will not be changed on context swap because it always needs to be connected to default one.