### PR TITLE
fix: remove unnecessary console logs in web-sockets

### DIFF
--- a/src/experimental/websocket.ts
+++ b/src/experimental/websocket.ts
@@ -37,12 +37,10 @@ export class ExperimentalWebSocket {
     }
 
     const fullUrl = `${this.url}?token=${encodeURIComponent(accessToken)}`;
-    console.log('Connecting to Experimental WebSocket:', fullUrl);
 
     this.ws = new WebSocket(fullUrl);
 
     this.ws.onopen = () => {
-      console.log('Experimental WebSocket connected.');
       this.clearReconnect();
     };
 


### PR DESCRIPTION
Removes unnecessary console log statements from the web-sockets implementation to clean up output .