### PR TITLE
feat: add ConnectionType enum for flexible login modal behavior

### DIFF
--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -9,6 +9,7 @@ import {
   ExecutionResponse,
   AppMode,
   SubscriptionEvent,
+  ConnectionType,
 } from '@calimero-network/calimero-client';
 import ExecutionModal from './ExecutionModal';
 import EventLog from './EventLog';
@@ -125,9 +126,44 @@ const AppContent: React.FC = () => {
           </div>
           <h1>My dApp</h1>
         </div>
-        <CalimeroConnectButton />
       </header>
       <main>
+        {!isAuthenticated && (
+          <div style={{ padding: '2rem', textAlign: 'center' }}>
+            <h2>Connection Type Examples</h2>
+            <div
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                justifyContent: 'center',
+                flexWrap: 'wrap',
+                marginBottom: '2rem',
+              }}
+            >
+              <div style={{ textAlign: 'center' }}>
+                <h3>Default (Both Local & Remote)</h3>
+                <CalimeroConnectButton />
+              </div>
+              <div style={{ textAlign: 'center' }}>
+                <h3>Local Only</h3>
+                <CalimeroConnectButton connectionType={ConnectionType.Local} />
+              </div>
+              <div style={{ textAlign: 'center' }}>
+                <h3>Remote Only</h3>
+                <CalimeroConnectButton connectionType={ConnectionType.Remote} />
+              </div>
+              <div style={{ textAlign: 'center' }}>
+                <h3>Custom URL (Skips Modal)</h3>
+                <CalimeroConnectButton
+                  connectionType={{
+                    type: ConnectionType.Custom,
+                    url: 'http://localhost:2528',
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
         {isAuthenticated ? (
           <div>
             <div

--- a/src/experimental/CalimeroConnectButton.tsx
+++ b/src/experimental/CalimeroConnectButton.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import styled from 'styled-components';
 import { useCalimero } from './CalimeroProvider';
 import CalimeroLogo from './CalimeroLogo';
+import { ConnectionType, CustomConnectionConfig } from './types';
 
 const StyledButton = styled.button`
   display: flex;
@@ -99,7 +100,13 @@ const DropdownInfoItem = styled.div`
   max-width: 150px;
 `;
 
-const CalimeroConnectButton: React.FC = () => {
+interface CalimeroConnectButtonProps {
+  connectionType?: ConnectionType | CustomConnectionConfig;
+}
+
+const CalimeroConnectButton: React.FC<CalimeroConnectButtonProps> = ({
+  connectionType = ConnectionType.RemoteAndLocal,
+}) => {
   const { isAuthenticated, login, logout, appUrl, isOnline } = useCalimero();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -163,7 +170,7 @@ const CalimeroConnectButton: React.FC = () => {
   }
 
   return (
-    <StyledButton onClick={login}>
+    <StyledButton onClick={() => login(connectionType)}>
       <CalimeroLogo className="calimero-logo" />
       Connect
     </StyledButton>

--- a/src/experimental/types.ts
+++ b/src/experimental/types.ts
@@ -12,6 +12,18 @@ export enum AppMode {
   MultiContext = 'multi-context',
 }
 
+export enum ConnectionType {
+  RemoteAndLocal = 'remote-and-local',
+  Local = 'local',
+  Remote = 'remote',
+  Custom = 'custom',
+}
+
+export interface CustomConnectionConfig {
+  type: ConnectionType.Custom;
+  url: string;
+}
+
 // Minimal representation of a context
 export interface Context {
   contextId: string;


### PR DESCRIPTION
- Add ConnectionType enum with RemoteAndLocal, Local, Remote, Custom options
- Update CalimeroConnectButton to accept connectionType prop
- Update CalimeroLoginModal to conditionally show UI based on connection type
- Update CalimeroProvider to handle Custom connection type (skips modal)
- Add example demonstrating all connection types
- Remove duplicate connect button from header in example