### PR TITLE
ci: add AI code review and doc auto-update workflows

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,0 +1,65 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+      agents:
+        description: "Number of agents (1-5)"
+        required: false
+        default: "3"
+        type: choice
+        options: ["1", "2", "3", "4", "5"]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git
+
+      - name: Determine PR number and agent count
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "agents=3"                                        >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run AI Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          ai-reviewer review-pr \
+            ${{ github.repository }} \
+            ${{ steps.pr.outputs.number }} \
+            --agents ${{ steps.pr.outputs.agents }} \
+            --reviewer-name "MeroReviewer" \
+            --output github

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,0 +1,25 @@
+name: Doc Auto-Update
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to generate docs for (leave blank to auto-detect)"
+        type: string
+        required: false
+      dry_run:
+        description: "Dry run: print changes without opening a PR"
+        type: boolean
+        default: false
+
+jobs:
+  doc-update:
+    uses: calimero-network/ai-code-reviewer/.github/workflows/doc-update.yaml@main
+    with:
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new GitHub Actions with PR write permissions and secret usage (Anthropic key/PAT), which can affect repo security and CI behavior if misconfigured.
> 
> **Overview**
> Adds a new **AI code review** GitHub Action (`ai-review.yaml`) that runs on PR events or manual dispatch, installs `ai-code-reviewer`, and posts review output back to the PR (configurable agent count, concurrency-cancelled).
> 
> Adds a **doc auto-update** workflow (`doc-update.yaml`) that triggers on pushes to `main`/`master` or manually, delegating to the reusable workflow in `calimero-network/ai-code-reviewer` and passing through `ANTHROPIC_API_KEY`/`GH_PAT` plus `dry_run` and optional PR number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75106061ec752dd2eb1cd2c216aa6d75a73b0172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->